### PR TITLE
Demonstrate how to include custom parameters in access code responses

### DIFF
--- a/db/authorization_codes.js
+++ b/db/authorization_codes.js
@@ -7,7 +7,7 @@ module.exports.find = (key, done) => {
   return done(new Error('Code Not Found'));
 };
 
-module.exports.save = (code, clientId, redirectUri, userId, done) => {
-  codes[code] = { clientId, redirectUri, userId };
+module.exports.save = (code, clientId, redirectUri, userId, userName, done) => {
+  codes[code] = { clientId, redirectUri, userId, userName };
   done();
 };

--- a/routes/oauth2.js
+++ b/routes/oauth2.js
@@ -78,11 +78,13 @@ server.exchange(oauth2orize.exchange.code((client, code, redirectUri, done) => {
     if (error) return done(error);
     if (client.id !== authCode.clientId) return done(null, false);
     if (redirectUri !== authCode.redirectUri) return done(null, false);
-    
+
     const token = utils.getUid(256);
     db.accessTokens.save(token, authCode.userId, authCode.clientId, (error) => {
       if (error) return done(error);
-      return done(null, token);
+      // Add custom params, e.g. the username
+      let params = { username: authCode.userName };
+      return done(null, token, null, params);
     });
   });
 }));


### PR DESCRIPTION
This adds the `username` property to access code responses, as an example for custom parameters. It was discussed a while ago in an oauth2orize issue: https://github.com/jaredhanson/oauth2orize/issues/119

I needed this to mock a [ORCID](https://members.orcid.org/api/oauth) oauth2 implementation. Maybe it's  helpful for others