### PR TITLE
Replace ZEIT Now with Vercel

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,17 +28,17 @@ Visit <http://localhost:3000/login> to see the server running locally.
 
 ## [Serverless](https://en.wikipedia.org/wiki/Serverless_computing)
 
-### [ZEIT Now](https://zeit.co/now)
+### [Vercel](https://vercel.com/home)
 
-1. [Download](https://zeit.co/download) either Now Desktop (preferred) or Now CLI.
-2. Create a `.nowignore` file in the root of the package (where package.json is located) with the following contents:
+1. [Download](https://vercel.com/download) either Vercel Desktop (preferred) or Vercel CLI.
+2. Create a `.vercelignore` file in the root of the package (where package.json is located) with the following contents:
 ```ignore
 node_modules
 .eslintrc
 LICENSE.md
 README.md
 ```
-3. Create a `now.json` file in the root of the package with the following contents:
+3. Create a `vercel.json` file in the root of the package with the following contents:
 ```json
 {
   "version": 2,
@@ -56,8 +56,8 @@ README.md
   ]
 }
 ```
-4. Execute `now` in the terminal/console. (If the command is not recognized, you might have to restart your computer.)
-5. Once you see the “Success! Deployment ready” message in the terminal, follow the URL of the deployment provided by the Now CLI.
+4. Execute `vercel` in the terminal/console. (If the command is not recognized, you might have to restart your computer.)
+5. Once you see the “Success! Deployment ready” message in the terminal, follow the URL of the deployment provided by the Vercel CLI.
 
 Provider / Consumer Walkthrough
 ===


### PR DESCRIPTION
ZEIT Now has changed its name to Vercel. (see [https://vercel.com/blog/zeit-is-now-vercel](https://vercel.com/blog/zeit-is-now-vercel))